### PR TITLE
Releave v2.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 See for sample https://raw.githubusercontent.com/favoloso/conventional-changelog-emoji/master/CHANGELOG.md
 -->
 
+## [2.2.1] - 2026-08-04
+
+### 🐛 Bug Fixes
+
+- Restore numeric keyboard on amount fields after Material UI update (#242)
+
 ## [2.2.0] - 2026-08-02
 
 ### 🛠 Improvements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ See for sample https://raw.githubusercontent.com/favoloso/conventional-changelog
 ### 🐛 Bug Fixes
 
 - Restore numeric keyboard on amount fields after Material UI update (#242)
+- Fix outlined TextField label overlapping the border on iOS Safari (#243)
 
 ## [2.2.0] - 2026-08-02
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "seven23",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "seven23",
-      "version": "2.2.0",
+      "version": "2.2.1",
       "dependencies": {
         "@date-io/moment": "^3.2.0",
         "@emotion/react": "^11.14.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "seven23",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "seven23",
   "scripts": {
     "start": "webpack serve --config webpack-dev-server.config.js",

--- a/src/app/components/Convertor.js
+++ b/src/app/components/Convertor.js
@@ -105,7 +105,9 @@ export default function Convertor(props) {
               >
                 <TextField
                   label="Amount to convert"
-                  inputProps={{ lang: "en", inputMode: "decimal" }}
+                  slotProps={{
+                    htmlInput: { lang: "en", inputMode: "decimal" },
+                  }}
                   onChange={(event) => setValueAndConvert(event.target.value)}
                   value={value}
                   disabled={!selectedCurrency}

--- a/src/app/components/changes/ChangeForm.js
+++ b/src/app/components/changes/ChangeForm.js
@@ -177,7 +177,9 @@ export default function ChangeForm(props) {
                   <TextField
                     label="Amount"
                     type="text"
-                    inputProps={{ lang: "en", inputMode: "decimal" }}
+                    slotProps={{
+                      htmlInput: { lang: "en", inputMode: "decimal" },
+                    }}
                     disabled={loading}
                     onChange={(event) =>
                       setLocal_amount(event.target.value.replace(",", "."))
@@ -213,7 +215,9 @@ export default function ChangeForm(props) {
                   <TextField
                     label="Amount"
                     type="text"
-                    inputProps={{ lang: "en", inputMode: "decimal" }}
+                    slotProps={{
+                      htmlInput: { lang: "en", inputMode: "decimal" },
+                    }}
                     disabled={loading}
                     onChange={(event) =>
                       setNew_amount(event.target.value.replace(",", "."))

--- a/src/app/components/transactions/TransactionForm.js
+++ b/src/app/components/transactions/TransactionForm.js
@@ -492,7 +492,9 @@ export default function TransactionForm(props) {
                   <TextField
                     type="text"
                     label="Amount"
-                    inputProps={{ lang: "en", inputMode: "decimal" }}
+                    slotProps={{
+                      htmlInput: { lang: "en", inputMode: "decimal" },
+                    }}
                     fullWidth
                     id="cy_transaction_amount"
                     disabled={isLoading}
@@ -577,7 +579,9 @@ export default function TransactionForm(props) {
                         <TextField
                           type="text"
                           label="Amount paid with"
-                          inputProps={{ lang: "en", inputMode: "decimal" }}
+                          slotProps={{
+                            htmlInput: { lang: "en", inputMode: "decimal" },
+                          }}
                           fullWidth
                           disabled={isLoading}
                           onChange={(event) =>
@@ -743,9 +747,11 @@ export default function TransactionForm(props) {
                                           <TextField
                                             type="text"
                                             label="Amount"
-                                            inputProps={{
-                                              lang: "en",
-                                              inputMode: "decimal",
+                                            slotProps={{
+                                              htmlInput: {
+                                                lang: "en",
+                                                inputMode: "decimal",
+                                              },
                                             }}
                                             fullWidth
                                             disabled={isLoading}

--- a/src/app/theme.js
+++ b/src/app/theme.js
@@ -30,6 +30,34 @@ const useTheme = () => {
             },
           },
         },
+        // Safari/iOS WebKit bug: outlined label notch fails to expand (especially
+        // in flex/Stack layouts), so the floating label overlaps the border.
+        // Upstream: https://github.com/mui/material-ui/issues/46891
+        // Pending fix: https://github.com/mui/material-ui/pull/48566
+        MuiOutlinedInput: {
+          styleOverrides: {
+            notchedOutline: {
+              "& > legend": {
+                transition: "none",
+              },
+            },
+            root: {
+              "&.Mui-focused > .MuiOutlinedInput-notchedOutline > legend": {
+                maxWidth: "none",
+              },
+            },
+          },
+        },
+        MuiFormControl: {
+          styleOverrides: {
+            root: {
+              "&:has(.MuiInputLabel-shrink) .MuiOutlinedInput-notchedOutline > legend":
+                {
+                  maxWidth: "none",
+                },
+            },
+          },
+        },
       },
     });
 


### PR DESCRIPTION
### 🐛 Bug Fixes

- Restore numeric keyboard on amount fields after Material UI update (#242)
- Fix outlined TextField label overlapping the border on iOS Safari (#243)